### PR TITLE
Don't depend on kee-frame as a checkout

### DIFF
--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,4 +1,4 @@
-^{:watch-dirs ["src/cljs" "checkouts/kee-frame/src"]
+^{:watch-dirs ["src/cljs"]
   :css-dirs   ["resources/public/css"]
   :open-url   false}
 {:main                 kee-frame-sample.core

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
                                       [ring/ring-defaults "0.2.1"]
                                       [compojure "1.6.0"]
                                       [environ "1.0.0"]
+                                      [kee-frame "0.4.1-SNAPSHOT"]
                                       [ring/ring-jetty-adapter "1.7.1"]]}
              :test    {:source-paths ["test"]
                        :dependencies [[etaoin "0.3.6"]]


### PR DESCRIPTION
I tried to run the sample on my machine but it complained that the kee-frame was included as a checkout. Here is a suggestion for a patch to remove that requirement.